### PR TITLE
feat: add `visibility` tag to subnets

### DIFF
--- a/vpc.tf
+++ b/vpc.tf
@@ -40,10 +40,12 @@ module "vpc" {
   public_subnet_tags = {
     "kubernetes.io/cluster/${var.nuon_id}" = "shared"
     "kubernetes.io/role/elb"               = 1
+    "visibility" = "public"
   }
 
   private_subnet_tags = {
     "kubernetes.io/cluster/${var.nuon_id}" = "shared"
     "kubernetes.io/role/internal-elb"      = 1
+    "visibility" = "private"
   }
 }


### PR DESCRIPTION
This adds the `visibility` (public/private) tag to the sandbox managed VPC.
