### PR TITLE
feat: add support for and admin access role

### DIFF
--- a/variables.tf
+++ b/variables.tf
@@ -104,3 +104,9 @@ variable "runner_install_role" {
   type        = string
   description = "The role that is used to install the runner, and should be granted access."
 }
+
+variable "admin_access_role" {
+  type        = string
+  default     = ""
+  description = "A role that be granted access cluster AmazonEKSAdminPolicy and AmazonEKSClusterAdminPolicy access."
+}


### PR DESCRIPTION
### Description

This PR adds support for an access role w/ the variable `admin_access_role`. It takes the arn of a role which will then be added to `module.eks.access_entries` with the cluster and eks admin roles. 


### Notes

1. if the new var is not set, the current behavior is preserved.
2. if it IS set to a valid role ARN, that role will get EKS and Cluster Admin access.
3. to enable it, add the `admin_access_role` var to the app's `[sandbox.vars]`.
4. to disable it, remove the `admin_access_role` var from `[sandbox.vars]`.  Note: simply setting `admin_access_role` to `""` won't work (for now).
