### PR TITLE
chore: ensure the vpc uses the same tag as the eks module

### DIFF
--- a/alb-ingress.tf
+++ b/alb-ingress.tf
@@ -19,6 +19,8 @@ module "alb_controller_irsa" {
       namespace_service_accounts = ["alb-ingress:${local.aws_alb_controller.service_account_name}"]
     }
   }
+
+  tags = local.tags
 }
 
 resource "helm_release" "alb-ingress-controller" {

--- a/cert-manager.tf
+++ b/cert-manager.tf
@@ -23,6 +23,8 @@ module "cert_manager_irsa" {
       namespace_service_accounts = ["${local.cert_manager.namespace}:${local.cert_manager.name}"]
     }
   }
+
+  tags = local.tags
 }
 
 resource "helm_release" "cert_manager" {

--- a/ebs-csi.tf
+++ b/ebs-csi.tf
@@ -18,6 +18,8 @@ module "ebs_csi_irsa" {
       namespace_service_accounts = ["${local.ebs_csi.name}:${local.ebs_csi.name}-sa"]
     }
   }
+
+  tags = local.tags
 }
 
 resource "helm_release" "ebs_csi" {

--- a/ecr.tf
+++ b/ecr.tf
@@ -14,4 +14,6 @@ module "ecr" {
   repository_encryption_type      = "KMS"
   repository_image_scan_on_push   = false
   repository_force_delete         = true
+
+  tags = local.tags
 }

--- a/eks.tf
+++ b/eks.tf
@@ -82,12 +82,6 @@ module "eks" {
     }
   }
 
-  # NOTE(fd): revisit the need for this
-  # HACK: https://github.com/terraform-aws-modules/terraform-aws-eks/issues/1986
-  node_security_group_tags = {
-    "kubernetes.io/cluster/${local.cluster_name}" = null
-  }
-
   # this can't rely on default_tags.
   # full set of tags must be specified here :sob:
   tags = local.tags

--- a/external-dns.tf
+++ b/external-dns.tf
@@ -31,6 +31,8 @@ module "external_dns_irsa" {
       namespace_service_accounts = ["${local.external_dns.namespace}:external-dns"]
     }
   }
+
+  tags = local.tags
 }
 
 resource "helm_release" "external_dns" {

--- a/odr.tf
+++ b/odr.tf
@@ -34,4 +34,6 @@ module "odr_iam_role" {
     aws_iam_policy.odr,
     module.eks,
   ]
+
+  tags = local.tags
 }

--- a/vpc.tf
+++ b/vpc.tf
@@ -48,4 +48,6 @@ module "vpc" {
     "kubernetes.io/role/internal-elb"             = 1
     "visibility"                                  = "private"
   }
+
+  tags = local.tags
 }


### PR DESCRIPTION
### Description

1. Ensure the VPC module uses the same tags as the EKS module for easier inventory tracking and cleanup.
2. Ensure the IAM Role modules also use the same tags as the EKS module. 
3. remove an unused tag on `node_security_group_tags` 
